### PR TITLE
Fix pylint errors

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -11,6 +11,7 @@ class PykickstartLintConfig(PocketLintConfig):
         self.falsePositives = [
             FalsePositive(r"^E1102.*: .*_TestCase.runTest: self.handler is not callable$"),
             FalsePositive(r"^W1113.*: Keyword argument before variable positional arguments list in the definition of __init__ function$"),
+            FalsePositive(r"^W0107.*: Unnecessary pass statement$"),
         ]
 
     @property


### PR DESCRIPTION
Ignore the warning from pylint 2.2.2 for unnecessary pass statement.