### PR TITLE
parser: use collections.abc to import Iterator

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -33,7 +33,7 @@ This module exports several important classes:
 
 from __future__ import print_function
 
-from collections import Iterator
+from collections.abc import Iterator
 import os
 import six
 import shlex


### PR DESCRIPTION
`collections.abc` was introduced in python 3.3. Importing these classes
from `collections` directly will be deprecated in 3.8 and already makes
the linting fail.

Note: we should move this into a `try` / `except ImportError` block if we care about python < 3.3. Do we?