### PR TITLE
Fix backward compatibility for python2

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -33,7 +33,11 @@ This module exports several important classes:
 
 from __future__ import print_function
 
-from collections.abc import Iterator
+try:
+    from collections.abc import Iterator
+except ImportError:  # python2 compatibility
+    from collections import Iterator
+
 import os
 import six
 import shlex


### PR DESCRIPTION
The `collections.abc` python module was introduced from python 3.3 but pykickstart still supports python 2 builds.

Introduced by PR https://github.com/dcantrell/pykickstart/pull/251.

@dcantrell I have found that thanks to our daily builds. You have now two options.

1) Merge this or similar patch (blue pill)
2) Drop python2 package from pykickstart (red pill)

The choice is your. Will you follow the white rabbit down to the rabbit hole?