### PR TITLE
Test on recent Python versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 install:
   - pip install --upgrade pip setuptools


### PR DESCRIPTION
At the moment 3.6 is in RHEL 8 and 3.7 in Fedora,
so I think it makes sense to run the Pykickstart
test suite on those in Travis as well.