### PR TITLE
Add pykickstart.spec.in for packit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,8 @@ bumpver: docs
 	make -C po pykickstart.pot ; \
 	zanata push $(ZANATA_PUSH_ARGS)
 
-pykickstart.spec:
-	cp pykickstart.spec.in pykickstart.spec
-	sed -i "s/%%VERSION%%/$(VERSION)/" pykickstart.spec
+pykickstart.spec: pykickstart.spec.in
+	sed -e "s/%%VERSION%%/$(VERSION)/" < $< > $@
 
 scratch-bumpver: docs
 	@NEWSUBVER=$$((`echo $(VERSION) |cut -d . -f 2` + 1)) ; \

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 	-$(COVERAGE) report -m --include="pykickstart/*,tools/*" | tee coverage-report.log
 
 clean:
-	-rm *.tar.gz pykickstart/*.pyc pykickstart/*/*.pyc tests/*.pyc tests/*/*.pyc docs/programmers-guide *log .coverage
+	-rm *.tar.gz pykickstart/*.pyc pykickstart/*/*.pyc tests/*.pyc tests/*/*.pyc docs/programmers-guide *log .coverage pykickstart.spec
 	$(MAKE) -C po clean
 	$(PYTHON) setup.py -q clean --all
 
@@ -109,6 +109,10 @@ bumpver: docs
 	make -C po pykickstart.pot ; \
 	zanata push $(ZANATA_PUSH_ARGS)
 
+pykickstart.spec:
+	cp pykickstart.spec.in pykickstart.spec
+	sed -i "s/%%VERSION%%/$(VERSION)/" pykickstart.spec
+
 scratch-bumpver: docs
 	@NEWSUBVER=$$((`echo $(VERSION) |cut -d . -f 2` + 1)) ; \
 	NEWVERSION=`echo $(VERSION).$$NEWSUBVER |cut -d . -f 1,3` ; \
@@ -125,7 +129,7 @@ scratch: docs
 	@rm -rf /tmp/pykickstart-$(VERSION)
 	@echo "The archive is in pykickstart-$(VERSION).tar.gz"
 
-rc-release: scratch-bumpver scratch
+rc-release: scratch-bumpver scratch pykickstart.spec
 	if [ -z "$(SPECFILE)" ]; then echo "SPECFILE must be set for this target" ; exit 1; fi
 	mock -r $(MOCKCHROOT) --scrub all || exit 1
 	mock -r $(MOCKCHROOT) --buildsrpm  --spec $(SPECFILE) --sources . --resultdir $(shell pwd) || exit 1

--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -1,0 +1,136 @@
+%if 0%{?rhel} > 7
+%bcond_with python2
+%else
+%bcond_without python2
+%endif
+
+# Disable tests by default because they fail to run inside mock builds
+# at the moment, but can run locally.  To build and run tests, do:
+#     rpmbuild -ba --with runtests pykickstart.spec
+%bcond_with runtests
+
+Name:      pykickstart
+Version:   %%VERSION%%
+Release:   1%{?dist}
+License:   GPLv2 and MIT
+Summary:   Python utilities for manipulating kickstart files.
+Url:       http://fedoraproject.org/wiki/pykickstart
+Source0:   https://github.com/dcantrell/%{name}/releases/download/r%{version}/%{name}-%{version}.tar.gz
+Source1:   https://github.com/dcantrell/%{name}/releases/download/r%{version}/%{name}-%{version}.tar.gz.asc
+
+BuildArch: noarch
+
+BuildRequires: gettext
+%if %{with python2}
+BuildRequires: python2-coverage
+BuildRequires: python2-devel
+BuildRequires: python2-nose
+BuildRequires: python2-ordered-set
+BuildRequires: python2-setuptools
+BuildRequires: python2-requests
+%endif
+
+BuildRequires: python3-coverage
+BuildRequires: python3-devel
+BuildRequires: python3-nose
+BuildRequires: python3-ordered-set
+BuildRequires: python3-requests
+BuildRequires: python3-setuptools
+BuildRequires: python3-six
+BuildRequires: python3-sphinx
+
+Requires: python3-kickstart = %{version}-%{release}
+
+%description
+Python utilities for manipulating kickstart files.  The Python 2 and 3
+libraries can be found in the packages python-kickstart and python3-kickstart
+respectively.
+
+%if %{with python2}
+# Python 2 library
+%package -n python2-kickstart
+%{?python_provide:%python_provide python2-kickstart}
+%{?python_provide:%python_provide python2-pykickstart}
+Summary:  Python 2 library for manipulating kickstart files.
+Requires: python2-six
+Requires: python2-requests
+Requires: python2-ordered-set
+
+%description -n python2-kickstart
+Python 2 library for manipulating kickstart files.  The binaries are found in
+the pykickstart package.
+%endif
+
+# Python 3 library
+%package -n python3-kickstart
+Summary:  Python 3 library for manipulating kickstart files.
+Requires: python3-six
+Requires: python3-requests
+Requires: python3-ordered-set
+
+%description -n python3-kickstart
+Python 3 library for manipulating kickstart files.  The binaries are found in
+the pykickstart package.
+
+%prep
+%setup -q
+
+%if %{with python2}
+rm -rf %{py3dir}
+mkdir %{py3dir}
+cp -a . %{py3dir}
+%endif
+
+%build
+%if %{with python2}
+make PYTHON=%{__python2}
+make -C %{py3dir} PYTHON=%{__python3}
+%else
+make PYTHON=%{__python3}
+%endif
+
+%install
+%if %{with python2}
+make PYTHON=%{__python2} DESTDIR=%{buildroot} install
+make -C %{py3dir} PYTHON=%{__python3} DESTDIR=%{buildroot} install
+%else
+make PYTHON=%{__python3} DESTDIR=%{buildroot} install
+%endif
+
+%check
+%if %{with runtests}
+%if %{with python2}
+make -C %{py3dir} PYTHON=%{__python3} test
+%else
+make PYTHON=%{__python3} test
+%endif
+%endif
+
+%files
+%license COPYING
+%doc README.rst
+%doc data/kickstart.vim
+%{_bindir}/ksvalidator
+%{_bindir}/ksflatten
+%{_bindir}/ksverdiff
+%{_bindir}/ksshell
+%{_mandir}/man1/ksflatten.1.gz
+%{_mandir}/man1/ksshell.1.gz
+%{_mandir}/man1/ksvalidator.1.gz
+%{_mandir}/man1/ksverdiff.1.gz
+
+%if %{with python2}
+%files -n python2-kickstart
+%doc docs/2to3
+%doc docs/programmers-guide
+%doc docs/kickstart-docs.txt
+%{python2_sitelib}/pykickstart*.egg-info
+%{python2_sitelib}/pykickstart
+%endif
+
+%files -n python3-kickstart
+%doc docs/2to3
+%doc docs/programmers-guide
+%doc docs/kickstart-docs.txt
+%{python3_sitelib}/pykickstart
+%{python3_sitelib}/pykickstart*.egg-info


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request is to follow up #259 .

The upstream repository contains temporary `pykickstart.spec.in` the file which is generated by Makefile `make pykickstart.spec`
