### PR TITLE
Make %packages --default attribute sane

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -371,36 +371,8 @@ class Packages(KickstartObject):
 
     def __str__(self):
         """Return a string formatted for output to a kickstart file."""
-        pkgs = ""
-
-        if not self.default:
-            if self.environment:
-                pkgs += "@^%s\n" % self.environment
-
-            grps = self.groupList
-            grps.sort()
-            for grp in grps:
-                pkgs += "%s\n" % grp.__str__()
-
-            p = self.packageList
-            p.sort()
-            for pkg in p:
-                pkgs += "%s\n" % pkg
-
-            grps = self.excludedGroupList
-            grps.sort()
-            for grp in grps:
-                pkgs += "-%s\n" % grp.__str__()
-
-            p = self.excludedList
-            p.sort()
-            for pkg in p:
-                pkgs += "-%s\n" % pkg
-
-            if pkgs == "" and not self.seen:
-                return ""
-
-        retval = "\n%packages"
+        pkgs = self._processPackagesContent()
+        retval = ""
 
         if self.default:
             retval += " --default"
@@ -423,10 +395,42 @@ class Packages(KickstartObject):
         if self.retries is not None:
             retval += " --retries=%d" % self.retries
 
+        if retval == "" and pkgs == "" and not self.seen:
+            return ""
+
         if self._ver >= version.F8:
-            return retval + "\n" + pkgs + "\n%end\n"
+            return "\n%packages" + retval + "\n" + pkgs + "\n%end\n"
         else:
-            return retval + "\n" + pkgs + "\n"
+            return "\n%packages" + retval + "\n" + pkgs + "\n"
+
+    def _processPackagesContent(self):
+        pkgs = ""
+
+        if not self.default:
+            if self.environment:
+                pkgs += "@^%s\n" % self.environment
+
+        grps = self.groupList
+        grps.sort()
+        for grp in grps:
+            pkgs += "%s\n" % grp.__str__()
+
+        p = self.packageList
+        p.sort()
+        for pkg in p:
+            pkgs += "%s\n" % pkg
+
+        grps = self.excludedGroupList
+        grps.sort()
+        for grp in grps:
+            pkgs += "-%s\n" % grp.__str__()
+
+        p = self.excludedList
+        p.sort()
+        for pkg in p:
+            pkgs += "-%s\n" % pkg
+
+        return pkgs
 
     def _processGroup(self, line):
         op = KSOptionParser(prog="", description="", version=version.DEVEL)

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -605,7 +605,7 @@ class PackageSection(Section):
 
         op.add_argument("--default", dest="defaultPackages", action="store_true",
                         default=False, version=F7, help="""
-                        Install the default package set. This corresponds to the
+                        Install the default environment. This corresponds to the
                         package set that would be installed if no other
                         selections were made on the package customization screen
                         during an interactive install.""")


### PR DESCRIPTION
The ``%packages --default`` will now force default environment. User can't change the environment even when he thinks he did. As a bonus Anaconda will use the user-set environment everywhere but not for installation.

All groups and packages written in the ``%packages`` section are installed correctly but they are not propagated to the output kickstart file.

In this commit I'm changing the output section generator to print all the groups and packages to the output kickstart but avoiding environment, which will be forced and can't be changed. Anaconda may change this behavior in the future but in that case the `--default` is not used and will be disabled.

Also change documentation to mention that only environment is set nothing else.