### PR TITLE
packit.yml: remove unused content

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -2,16 +2,6 @@ specfile_path: pykickstart.spec.in
 synced_files:
   - packit.yaml
   - pykickstart.spec.in
-jobs:
-  - trigger: release
-    release_to:
-      - master
-  - trigger: pull_request
-    release_to:
-      - master
 upstream_project_name: pykickstart
 downstream_package_name: pykickstart
 dist_git_url: https://src.fedoraproject.org/rpms/pykickstart.git
-checks:
-  - name: simple-koji-ci
-  - name: Fedora CI


### PR DESCRIPTION
We are working on a next release of packit where we'll finally implement jobs.
Our current plan is to change the schema, which means that future version of
packit would fail parsing this config file.

This PR therefore removes content from packit.yml which packit does not even
process now.