### PR TITLE
A couple fixes for %packaging section docs

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -454,7 +454,8 @@ class PackageSection(Section):
                             Packages can be specified by group or by individual
                             package name. The installation program defines
                             several groups that contain related packages. Refer
-                            to the repodata/\\*comps\\*.xml file on the first CD-ROM
+                            to the repodata/\\*comps\\*.xml file on the
+                            installation media or in installation repository
                             for a list of groups. Each group has an id, user
                             visibility value, name, description, and package
                             list. In the package list, the packages marked as
@@ -588,8 +589,8 @@ class PackageSection(Section):
                         version=FC4)
         op.add_argument("--ignoremissing", action="store_true", default=False,
                         help="""
-                        Ignore any packages or groups specified in the packages
-                        section that are not found in any configured repository.
+                        Ignore any packages, groups or module streams specified in the
+                        packages section that are not found in any configured repository.
                         The default behavior is to halt the installation and ask
                         the user if the installation should be aborted or
                         continued. This option allows fully automated


### PR DESCRIPTION
Drop the reference to "first CD-ROM" and "installation media"
instead and also note comps files might be found in the network
installation repos as well.

Also note that --ignoremissing should work for module streams as well.