### PR TITLE
Fix the documentation of bootloader --append

### DIFF
--- a/docs/gen_commands_docs
+++ b/docs/gen_commands_docs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
-sys.path.append("../")
+sys.path.insert(0, "../")
 from pykickstart.handlers import control
 from pykickstart.version import DEVEL, stringToVersion, versionToString, \
     getVersionFromCommandClass

--- a/docs/gen_sections_docs
+++ b/docs/gen_sections_docs
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
-sys.path.append("../")
+sys.path.insert(0, "../")
 from pykickstart import sections
 from pykickstart.version import returnClassForVersion, DEVEL
 

--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -93,13 +93,14 @@ class FC3_Bootloader(KickstartCommand):
                             partition, adding a ``part biosboot`` option is
                             unnecessary.""", version=FC3)
         op.add_argument("--append", dest="appendLine", version=FC3, help="""
-                        Specifies kernel parameters. The default set of bootloader
-                        arguments is "rhgb quiet". You will get this set of
-                        arguments regardless of what parameters you pass to
-                        --append, or if you leave out --append entirely.
-                        For example::
+                        Specifies additional kernel parameters. For example:
 
                         ``bootloader --location=mbr --append="hdd=ide-scsi ide=nodma"``
+
+                        **Note** The installer will add the bootloader arguments ``rhgb
+                        quiet`` if plymouth is installed on the target system. You can
+                        disable these options with ``-plymouth`` in the ``%%packages``
+                        section.
                         """)
         op.add_argument("--linear", action="store_true", default=True,
                         version=FC3, help="use linear mode to access hard disks (for LILO only)")


### PR DESCRIPTION
Specify when the installer adds the bootloader options `rhgb quiet`
and how they can be disabled.

We need to prepend a path to the local repository to `sys.path`,
so the documentation for kickstart commands and handlers can be
generated from the source files in the repository instead of
files of the installed pykickstart package.